### PR TITLE
Allow custom configs pdo

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -337,6 +337,11 @@ return [
         'pdo' => [
             'driver'   => 'pdo',
             'database' => 'default',
+			'table_prefix' => 'flysystem',
+            'enable_compression' => true,
+            'chunk_size' => 1048576, //1MB
+            'temp_dir' => sys_get_temp_dir(),
+            'disable_mysql_buffering' => true,
         ],
 
         'qcloud' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -337,7 +337,7 @@ return [
         'pdo' => [
             'driver'   => 'pdo',
             'database' => 'default',
-			'table_prefix' => 'flysystem',
+            'table_prefix' => 'flysystem',
             'enable_compression' => true,
             'chunk_size' => 1048576, //1MB
             'temp_dir' => sys_get_temp_dir(),

--- a/src/FlysystemOtherManager.php
+++ b/src/FlysystemOtherManager.php
@@ -251,7 +251,17 @@ class FlysystemOtherManager extends FlysystemManager
             });
         } elseif (class_exists('\Phlib\Flysystem\Pdo\PdoAdapter')) {
             $this->extend('pdo', function ($app, $config) {
-                return $this->createFlysystem(new \Phlib\Flysystem\Pdo\PdoAdapter(\DB::connection($config['database'])->getPdo()), $config);
+                $driverConfig = Arr::only($config, [
+					'database',
+					'visbility',
+					'table_prefix',
+					'enable_compression',
+					'chunk_size',
+					'temp_dir',
+					'disable_mysql_buffering',
+				]);
+
+                return $this->createFlysystem(new \Phlib\Flysystem\Pdo\PdoAdapter(\DB::connection($config['database'])->getPdo()), $config, $driverConfig);
             });
         }
 

--- a/src/FlysystemOtherManager.php
+++ b/src/FlysystemOtherManager.php
@@ -251,7 +251,7 @@ class FlysystemOtherManager extends FlysystemManager
             });
         } elseif (class_exists('\Phlib\Flysystem\Pdo\PdoAdapter')) {
             $this->extend('pdo', function ($app, $config) {
-                return $this->createFlysystem(new \Phlib\Flysystem\Pdo\PdoAdapter(DB::connection($config['database'])->getPdo()), $config);
+                return $this->createFlysystem(new \Phlib\Flysystem\Pdo\PdoAdapter(\DB::connection($config['database'])->getPdo()), $config);
             });
         }
 

--- a/src/FlysystemOtherManager.php
+++ b/src/FlysystemOtherManager.php
@@ -4,7 +4,8 @@ namespace Danhunsaker\Laravel\Flysystem;
 
 use Danhunsaker\Laravel\Flysystem\FlysystemManager;
 use Illuminate\Support\Arr;
-use Log;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class FlysystemOtherManager extends FlysystemManager
 {
@@ -251,17 +252,16 @@ class FlysystemOtherManager extends FlysystemManager
             });
         } elseif (class_exists('\Phlib\Flysystem\Pdo\PdoAdapter')) {
             $this->extend('pdo', function ($app, $config) {
-                $driverConfig = Arr::only($config, [
-					'database',
-					'visbility',
-					'table_prefix',
-					'enable_compression',
-					'chunk_size',
-					'temp_dir',
-					'disable_mysql_buffering',
-				]);
+                $driverConfig = new \League\Flysystem\Config(Arr::only($config, [
+                    'visbility',
+                    'table_prefix',
+                    'enable_compression',
+                    'chunk_size',
+                    'temp_dir',
+                    'disable_mysql_buffering',
+                ]));
 
-                return $this->createFlysystem(new \Phlib\Flysystem\Pdo\PdoAdapter(\DB::connection($config['database'])->getPdo()), $config, $driverConfig);
+                return $this->createFlysystem(new \Phlib\Flysystem\Pdo\PdoAdapter(DB::connection($config['database'])->getPdo(), $driverConfig), $config);
             });
         }
 


### PR DESCRIPTION
This PR, mixed with [this one](https://github.com/danhunsaker/laravel-flysystem-service/pull/1) in the laravel-flysystem-service, will allow to pass custom configurations to the PDO Adapter.

I realize there could be a better way to handle this, like exporting in another constants class the array for each specific driver and merge it with global keys (like 'visbility' or 'database'). This is just a tiny example (which works) but if need I can try and organize it a bit better. 